### PR TITLE
feat: add GroundTruthJSON

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,10 +15,10 @@ import (
 
 // GroundTruth represents the "known good" verified of the enclave
 type GroundTruth struct {
-	PublicKey          string
-	Digest             string
-	CodeMeasurement    *attestation.Measurement
-	EnclaveMeasurement *attestation.Measurement
+	PublicKey          string                   `json:"public_key"`
+	Digest             string                   `json:"digest"`
+	CodeMeasurement    *attestation.Measurement `json:"code_measurement"`
+	EnclaveMeasurement *attestation.Measurement `json:"enclave_measurement"`
 }
 
 type SecureClient struct {
@@ -46,6 +47,15 @@ func (s *SecureClient) Repo() string {
 // GroundTruth returns the last verified enclave state
 func (s *SecureClient) GroundTruth() *GroundTruth {
 	return s.groundTruth
+}
+
+// GroundTruthJSON returns the ground truth as a JSON string
+func (s *SecureClient) GroundTruthJSON() (string, error) {
+	json, err := json.Marshal(s.groundTruth)
+	if err != nil {
+		return "", err
+	}
+	return string(json), nil
 }
 
 // Verify fetches the latest verification information from GitHub and Sigstore and stores the ground truth results in the client

--- a/client/client.go
+++ b/client/client.go
@@ -51,11 +51,11 @@ func (s *SecureClient) GroundTruth() *GroundTruth {
 
 // GroundTruthJSON returns the ground truth as a JSON string
 func (s *SecureClient) GroundTruthJSON() (string, error) {
-	json, err := json.Marshal(s.groundTruth)
+	encoded, err := json.Marshal(s.groundTruth)
 	if err != nil {
 		return "", err
 	}
-	return string(json), nil
+	return string(encoded), nil
 }
 
 // Verify fetches the latest verification information from GitHub and Sigstore and stores the ground truth results in the client

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,9 +1,11 @@
 package client
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tinfoilsh/verifier/attestation"
 )
 
 func TestVerify(t *testing.T) {
@@ -23,4 +25,30 @@ func TestVerify(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestClientGroundTruthJSON(t *testing.T) {
+	gt := &GroundTruth{
+		PublicKey: "pubkey",
+		Digest:    "feabcd",
+		CodeMeasurement: &attestation.Measurement{
+			Type:      attestation.SnpTdxMultiPlatformV1,
+			Registers: []string{"a", "b"},
+		},
+		EnclaveMeasurement: &attestation.Measurement{
+			Type:      attestation.TdxGuestV1,
+			Registers: []string{"a"},
+		},
+	}
+	client := &SecureClient{
+		groundTruth: gt,
+	}
+
+	encoded, err := client.GroundTruthJSON()
+	assert.NoError(t, err)
+
+	// Decode and compare
+	var gt2 GroundTruth
+	assert.NoError(t, json.Unmarshal([]byte(encoded), &gt2))
+	assert.Equal(t, gt, &gt2)
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a GroundTruthJSON method to SecureClient to return the ground truth as a JSON string.

- **New Features**
  - Added GroundTruthJSON for easy JSON serialization of ground truth data.
  - Updated tests to cover the new method.

<!-- End of auto-generated description by cubic. -->

