### PR TITLE
fix: downgrade to macos 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Pin the release workflow to macos-14 instead of macos-latest to stabilize CI and avoid unexpected runner changes. This ensures a consistent environment for release builds.

<!-- End of auto-generated description by cubic. -->

