### PR TITLE
nit: clarify endpoint function

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -423,7 +423,7 @@ func FetchAndVerifyJSON(repo string, sigstoreTrustedRootJSON []byte) (string, er
 }
 
 // FetchAndVerifyFromURLJSON fetches an attestation bundle from a custom URL and verifies it.
-// If attestationBundleURL is empty, defaults to the Tinfoil attestation service.
+// If attestationBundleURL is empty, defaults to the Tinfoil bundle endpoint.
 // Returns the verification data as a JSON string.
 func FetchAndVerifyFromURLJSON(attestationBundleURL, repo string, sigstoreTrustedRootJSON []byte) (string, error) {
 	var bundle *attestation.Bundle


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the doc comment for FetchAndVerifyFromURLJSON to say it defaults to the Tinfoil bundle endpoint when the URL is empty. No code or behavior changes.

<sup>Written for commit 6b547bb452929484d9e4e1f9989de688599c3266. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

